### PR TITLE
Fix missing GUI namebox variables

### DIFF
--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -64,6 +64,8 @@ define gui.textbox_yalign = 1.0
 # Placement of the speaking character's name
 define gui.name_xpos = 240
 define gui.name_ypos = 0
+define gui.namebox_width = None
+define gui.namebox_height = None
 
 # Placement of dialogue text
 define gui.dialogue_xpos = 268


### PR DESCRIPTION
## Summary
- Add missing `gui.namebox_width` and `gui.namebox_height` variables to gui.rpy
- Fixes AttributeError that occurred on game launch when screens.rpy referenced undefined variables

## Test plan
- [x] Run the game with `./renpy-8.3.3-sdk/renpy.sh .`
- [x] Verify game launches without errors
- [x] Verify dialogue boxes display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)